### PR TITLE
add order_status seed + tests

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -2,7 +2,7 @@
 # Name your project! Project names should contain only lowercase characters
 # and underscores. A good package name should reflect your organization's
 # name or the intended use of these models
-name: 'my_new_project'
+name: 'cea_aw'
 version: '1.0.0'
 config-version: 2
 
@@ -23,20 +23,3 @@ target-path: "target"  # directory which will store compiled SQL files
 clean-targets:         # directories to be removed by `dbt clean`
   - "target"
   - "dbt_packages"
-
-
-# Configuring models
-# Full documentation: https://docs.getdbt.com/docs/configuring-models
-
-# In dbt, the default materialization for a model is a view. This means, when you run 
-# dbt run or dbt build, all of your models will be built as a view in your data platform. 
-# The configuration below will override this setting for models in the example folder to 
-# instead be materialized as tables. Any models you add to the root of the models folder will 
-# continue to be built as views. These settings can be overridden in the individual model files
-# using the `{{ config(...) }}` macro.
-
-models:
-  my_new_project:
-    # Applies to all files under models/example/
-    example:
-      +materialized: table

--- a/models/sources/raw.yml
+++ b/models/sources/raw.yml
@@ -2,53 +2,67 @@ version: 2
 
 sources:
   - name: raw_adventure_works
-    # herda o database do ambiente (FEA25_05)
+    # Database is inherited from the environment (target.database = FEA25_05).
     schema: raw_adventure_works
-    description: "Tabelas brutas da AdventureWorks usadas no domínio Sales."
+    description: "Raw AdventureWorks tables used for the Sales domain."
+
     tables:
 
-      # ----- SALES -----
+      # SALES
       - name: salesorderheader
         identifier: SALES_SALESORDERHEADER
-        description: "Cabeçalho dos pedidos."
+        description: "Order headers."
         columns:
           - name: SalesOrderID
+            description: "Primary key of the order header."
             tests: [not_null, unique]
           - name: CustomerID
+            description: "Customer identifier."
             tests: [not_null]
           - name: OrderDate
+            description: "Order creation date."
             tests: [not_null]
 
       - name: salesorderdetail
         identifier: SALES_SALESORDERDETAIL
-        description: "Linhas (itens) dos pedidos."
+        description: "Order line items (detail rows)."
         tests:
           - dbt_utils.unique_combination_of_columns:
               combination_of_columns: [SalesOrderID, SalesOrderDetailID]
         columns:
-          - name: SalesOrderID       # FK para header
+          - name: SalesOrderID
+            description: "FK to order header."
             tests: [not_null]
           - name: SalesOrderDetailID
+            description: "Line identifier inside an order."
             tests: [not_null]
           - name: ProductID
+            description: "FK to product."
             tests: [not_null]
           - name: OrderQty
+            description: "Quantity ordered."
             tests: [not_null]
           - name: UnitPrice
+            description: "Unit price applied on the line."
             tests: [not_null]
           - name: UnitPriceDiscount
+            description: "Unit discount applied on the line."
             tests: [not_null]
 
       - name: customer
         identifier: SALES_CUSTOMER
+        description: "Customers (person or store accounts)."
         columns:
           - name: CustomerID
             tests: [not_null, unique]
           - name: PersonID
+            description: "FK to person (nullable when it is a store)."
           - name: StoreID
+            description: "FK to store (nullable when it is a person)."
 
       - name: salesperson
         identifier: SALES_SALESPERSON
+        description: "Salespeople and their attributes."
         columns:
           - name: BusinessEntityID
             tests: [not_null, unique]
@@ -57,6 +71,7 @@ sources:
 
       - name: store
         identifier: SALES_STORE
+        description: "Stores (B2B customers)."
         columns:
           - name: BusinessEntityID
             tests: [not_null, unique]
@@ -65,6 +80,7 @@ sources:
 
       - name: creditcard
         identifier: SALES_CREDITCARD
+        description: "Credit cards used by customers."
         columns:
           - name: CreditCardID
             tests: [not_null, unique]
@@ -73,6 +89,7 @@ sources:
 
       - name: salesreason
         identifier: SALES_SALESREASON
+        description: "Sales reasons (e.g., Promotion, Marketing)."
         columns:
           - name: SalesReasonID
             tests: [not_null, unique]
@@ -83,6 +100,7 @@ sources:
 
       - name: salesorderheadersalesreason
         identifier: SALES_SALESORDERHEADERSALESREASON
+        description: "Bridge between orders and sales reasons (M:N)."
         tests:
           - dbt_utils.unique_combination_of_columns:
               combination_of_columns: [SalesOrderID, SalesReasonID]
@@ -92,9 +110,10 @@ sources:
           - name: SalesReasonID
             tests: [not_null]
 
-      # ----- PRODUCTION (produtos) -----
+      # PRODUCTION
       - name: product
         identifier: PRODUCTION_PRODUCT
+        description: "Products catalog."
         columns:
           - name: ProductID
             tests: [not_null, unique]
@@ -104,6 +123,7 @@ sources:
 
       - name: productsubcategory
         identifier: PRODUCTION_PRODUCTSUBCATEGORY
+        description: "Product subcategories."
         columns:
           - name: ProductSubcategoryID
             tests: [not_null, unique]
@@ -114,15 +134,17 @@ sources:
 
       - name: productcategory
         identifier: PRODUCTION_PRODUCTCATEGORY
+        description: "Product categories."
         columns:
           - name: ProductCategoryID
             tests: [not_null, unique]
           - name: Name
             tests: [not_null]
 
-      # ----- PERSON (geografia & pessoa) -----
+      # PERSON
       - name: person
         identifier: PERSON_PERSON
+        description: "Persons (names and types)."
         columns:
           - name: BusinessEntityID
             tests: [not_null, unique]
@@ -130,6 +152,7 @@ sources:
 
       - name: address
         identifier: PERSON_ADDRESS
+        description: "Addresses (city + state/province)."
         columns:
           - name: AddressID
             tests: [not_null, unique]
@@ -140,6 +163,7 @@ sources:
 
       - name: stateprovince
         identifier: PERSON_STATEPROVINCE
+        description: "States/Provinces and their country codes."
         columns:
           - name: StateProvinceID
             tests: [not_null, unique]
@@ -150,6 +174,7 @@ sources:
 
       - name: countryregion
         identifier: PERSON_COUNTRYREGION
+        description: "Country/Region reference table."
         columns:
           - name: CountryRegionCode
             tests: [not_null, unique]

--- a/seeds/order_status.csv
+++ b/seeds/order_status.csv
@@ -1,0 +1,7 @@
+order_status_code,order_status_name
+1,In process
+2,Approved
+3,Backordered
+4,Rejected
+5,Shipped
+6,Cancelled

--- a/seeds/schema.yml
+++ b/seeds/schema.yml
@@ -1,0 +1,26 @@
+version: 2
+
+seeds:
+  - name: order_status
+    description: "Dictionary for SalesOrderHeader.Status."
+    columns:
+      - name: order_status_code
+        description: "Status code from the OLTP (SalesOrderHeader.Status)."
+        tests:
+          - not_null
+          - unique
+          - accepted_values:
+              values: [1, 2, 3, 4, 5, 6]
+
+      - name: order_status_name
+        description: "Human-readable status name."
+        tests:
+          - not_null
+          - accepted_values:
+              values:
+                - In process
+                - Approved
+                - Backordered
+                - Rejected
+                - Shipped
+                - Cancelled


### PR DESCRIPTION
### Why
Add a canonical dictionary for `SalesOrderHeader.Status` to replace magic numbers, standardize status names, and simplify downstream joins/filters.

### What
- Add `seeds/order_status.csv` (codes 1..6 with names).
- Add `seeds/schema.yml` tests:
  - `order_status_code`: `not_null`, `unique`, `accepted_values` [1..6]
  - `order_status_name`: `not_null`, `accepted_values`

### Checklist (must be green before merge)
- [x] All models run successfully (`dbt build -s state:modified+` passed)
- [x] Tests added/updated and passing (not_null/unique/unique_combo as needed)
- [x] Sources/Models/Seeds documented in `schema.yml` (EN)
- [x] Materialization consistent (staging=view, intermediate=view, marts=table) or explicitly set
- [x] Naming & SQL style follow corporate guidelines