### PR TITLE
add stg_sales__order_header and tests + drop status→seed relationship…

### DIFF
--- a/models/staging/sales/stg_sales.yml
+++ b/models/staging/sales/stg_sales.yml
@@ -1,0 +1,61 @@
+version: 2
+
+models:
+  - name: stg_sales__order_header
+    description: "Cleaned order headers for downstream marts."
+    columns:
+      - name: sales_order_id
+        description: "Natural key of the order header."
+        tests: [not_null, unique]
+
+      - name: order_date
+        description: "Order creation date."
+        tests: [not_null]
+
+      - name: status_code
+        description: "Numeric status code; mapped to a name via seed downstream."
+        tests: [not_null]
+
+      - name: customer_id
+        description: "FK to sales customer."
+        tests: [not_null]
+
+      - name: ship_to_address_id
+        description: "FK to ship-to address."
+        tests: [not_null]
+
+      - name: credit_card_id
+        description: "FK to credit card used in the order (nullable)."
+
+      - name: subtotal_amount
+        description: "Sum of line amounts before taxes and freight."
+        tests:
+          - dbt_utils.expression_is_true:
+              expression: ">= 0"
+              severity: warn
+
+      - name: tax_amount
+        description: "Total taxes charged on the order."
+        tests:
+          - dbt_utils.expression_is_true:
+              expression: ">= 0"
+              severity: warn
+
+      - name: freight_amount
+        description: "Shipping freight amount."
+        tests:
+          - dbt_utils.expression_is_true:
+              expression: ">= 0"
+              severity: warn
+
+      - name: total_due_amount
+        description: "Final amount due (subtotal + tax + freight)."
+        tests:
+          - dbt_utils.expression_is_true:
+              expression: ">= 0"
+              severity: warn
+
+    tests:
+      - dbt_utils.expression_is_true:
+          expression: "abs(total_due_amount - (subtotal_amount + tax_amount + freight_amount)) <= 0.01"
+          severity: warn

--- a/models/staging/sales/stg_sales__order_header.sql
+++ b/models/staging/sales/stg_sales__order_header.sql
@@ -1,0 +1,21 @@
+with
+    source as (
+        select *
+        from {{ source('raw_adventure_works', 'salesorderheader') }}
+    )
+  , renamed as (
+        select
+            cast(SalesOrderID as number)    as sales_order_id
+          , cast(OrderDate as date)         as order_date
+          , cast(Status as number)          as status_code
+          , cast(CustomerID as number)      as customer_id
+          , cast(ShipToAddressID as number) as ship_to_address_id
+          , cast(CreditCardID as number)    as credit_card_id
+          , cast(SubTotal as number(18,2))  as subtotal_amount
+          , cast(TaxAmt as number(18,2))    as tax_amount
+          , cast(Freight as number(18,2))   as freight_amount
+          , cast(TotalDue as number(18,2))  as total_due_amount
+        from source
+    )
+select *
+from renamed


### PR DESCRIPTION
### Why
Expose a clean order header staging model for downstream marts and keep validations “left-shifted”. Remove the status→seed relationship from staging to avoid duplicated checks (it will live in sources on the next PR).

### What changed
- Added `models/staging/sales/stg_sales__order_header.sql` (lean, casted/renamed columns used by marts).
- Added `models/staging/sales/stg_sales.yml`:
  - Tests: `sales_order_id` (not_null, unique), `order_date` (not_null),
    `customer_id` (not_null), `ship_to_address_id` (not_null).
  - Monetary checks (warn): `subtotal_amount`, `tax_amount`, `freight_amount`, `total_due_amount` ≥ 0.
  - Model-level arithmetic check (warn): `abs(total_due_amount - (subtotal_amount + tax_amount + freight_amount)) <= 0.01`.
- Dropped `status_code → order_status (seed)` relationship from staging (to be enforced at the source layer in a follow-up PR).

### Checklist
- [x] All changed models run successfully (`dbt build`) for this branch.
- [x] Sources/models have descriptions (docs updated).
- [x] Tests added/updated and passing (not_null, unique, relationships, data tests when applicable).
- [x] Changes limited to this feature/scope (no unrelated files).
- [x] Naming & SQL style follow corporate guidelines.
