### PR TITLE
add stg_production__product + tests/docs

### DIFF
--- a/models/staging/production/stg_production.yml
+++ b/models/staging/production/stg_production.yml
@@ -1,0 +1,19 @@
+version: 2
+
+models:
+  - name: stg_production__product
+    description: "Cleaned products enriched with subcategory and category names."
+    columns:
+      - name: product_id
+        description: "Natural key of the product."
+        tests: [not_null, unique]
+
+      - name: product_name
+        description: "Product display name."
+        tests: [not_null]
+
+      - name: subcategory_name
+        description: "Subcategory name (nullable when product has no subcategory)."
+
+      - name: category_name
+        description: "Category name (nullable when product has no subcategory/category)."

--- a/models/staging/production/stg_production__product.sql
+++ b/models/staging/production/stg_production__product.sql
@@ -1,0 +1,39 @@
+with
+    product as (
+        select
+            productid              as product_id
+            , name                 as product_name
+            , productsubcategoryid as product_subcategory_id
+        from {{ source('raw_adventure_works', 'product') }}
+    )
+
+    , subcategory as (
+        select
+            productsubcategoryid as product_subcategory_id
+            , name               as subcategory_name
+            , productcategoryid  as product_category_id
+        from {{ source('raw_adventure_works', 'productsubcategory') }}
+    )
+
+    , category as (
+        select
+            productcategoryid as product_category_id
+            , name            as category_name
+        from {{ source('raw_adventure_works', 'productcategory') }}
+    )
+
+    , joined as (
+        select
+            p.product_id
+            , p.product_name
+            , s.subcategory_name
+            , c.category_name
+        from product p
+        left join subcategory s
+            on s.product_subcategory_id = p.product_subcategory_id
+        left join category c
+            on c.product_category_id = s.product_category_id
+    )
+
+select *
+from joined


### PR DESCRIPTION
### Why
Expose a clean product staging model enriched with subcategory/category names for downstream dims/facts, keeping validations minimal and non-duplicated.

### What changed
- Added `models/staging/production/stg_production__product.sql` (joins product ⇢ subcategory ⇢ category, selects only required columns).
- Added `models/staging/production/product.yml`:
  - Tests: `product_id` (not_null, unique), `product_name` (not_null).
  - Docs for `subcategory_name` and `category_name` (nullable by design).

### Checklist
- [x] All changed models run successfully (`dbt build`) for this branch.
- [x] Sources/models have descriptions (docs updated).
- [x] Tests added/updated and passing (not_null, unique, relationships, data tests when applicable).
- [x] Changes limited to this feature/scope (no unrelated files).
- [x] Naming & SQL style follow corporate guidelines.
