### PR TITLE
add stg_sales__customer with warns for missing names

### DIFF
--- a/models/staging/sales/stg_sales.yml
+++ b/models/staging/sales/stg_sales.yml
@@ -82,3 +82,30 @@ models:
 
       - name: unit_price_discount
         description: "Unit discount applied on the line (0..1)."
+
+  - name: stg_sales__customer
+    description: "Cleaned customers unified from person/store with a single display name."
+    columns:
+      - name: customer_id
+        description: "Natural key of the customer."
+        tests: [not_null, unique]
+
+      - name: customer_type
+        description: "Customer kind derived from available link (Person / Store / Unknown)."
+        tests:
+          - accepted_values:
+              values: ['Person', 'Store', 'Unknown']
+              severity: warn
+
+      - name: customer_name
+        description: "Display name: store name or person full name."
+        tests:
+          - not_null:
+              severity: warn
+
+      - name: person_id
+        description: "FK to person (nullable for store customers)."
+
+      - name: store_id
+        description: "FK to store (nullable for person customers)."
+

--- a/models/staging/sales/stg_sales__customer.sql
+++ b/models/staging/sales/stg_sales__customer.sql
@@ -1,0 +1,48 @@
+with
+    customer as (
+        select
+            CustomerID
+            , PersonID
+            , StoreID
+        from {{ source('raw_adventure_works', 'customer') }}
+    )
+
+    , person as (
+        select
+            BusinessEntityID as person_id
+            , FirstName
+            , MiddleName
+            , LastName
+        from {{ source('raw_adventure_works', 'person') }}
+    )
+
+    , store as (
+        select
+            BusinessEntityID as store_id
+            , Name           as store_name
+        from {{ source('raw_adventure_works', 'store') }}
+    )
+
+    , final as (
+        select
+            cast(c.CustomerID as number) as customer_id
+            , cast(c.PersonID as number) as person_id
+            , cast(c.StoreID  as number) as store_id
+            , case
+                when s.store_id is not null then 'Store'
+                when p.person_id is not null then 'Person'
+                else 'Unknown'
+            end as customer_type
+            , coalesce(
+                s.store_name
+                , nullif(trim(concat_ws(' ', p.FirstName, p.MiddleName, p.LastName)), '')
+            ) as customer_name
+        from customer c
+        left join person p
+            on p.person_id = c.PersonID
+        left join store s
+            on s.store_id = c.StoreID
+    )
+
+select *
+from final


### PR DESCRIPTION
### Why
Introduce cleaned Sales customers for downstream dims/facts, while surfacing missing names as warnings.

### What changed
- New model `stg_sales__customer` (person/store join + selected fields).
- Tests: `unique`/`not_null` on `customer_id`; `accepted_values` on `customer_type`; `not_null` on `customer_name` as `severity: warn`.

### Checklist
- [x] `dbt build -s stg_sales__customer` passes (with expected warns).
- [x] Docs/descriptions added/updated.
- [x] Scope limited to this feature.
- [x] Naming & SQL style follow corporate guidelines.
