### PR TITLE
add stg_sales__credit_card model + tests/docs

### DIFF
--- a/models/staging/sales/stg_sales.yml
+++ b/models/staging/sales/stg_sales.yml
@@ -109,3 +109,15 @@ models:
       - name: store_id
         description: "FK to store (nullable for person customers)."
 
+  - name: stg_sales__credit_card
+    description: "Credit card reference from OLTP with the minimal fields used downstream."
+    columns:
+      - name: credit_card_id
+        description: "Natural key of the credit card."
+        tests: [not_null, unique]
+
+      - name: card_type
+        description: "Card brand/type (e.g., Vista, SuperiorCard, etc.)."
+        tests: [not_null]
+
+

--- a/models/staging/sales/stg_sales__credit_card.sql
+++ b/models/staging/sales/stg_sales__credit_card.sql
@@ -1,0 +1,17 @@
+with
+    source as (
+        select
+            CreditCardID,
+            CardType
+        from {{ source('raw_adventure_works', 'creditcard') }}
+    )
+
+    , renamed as (
+        select
+            cast(CreditCardID as int)  as credit_card_id
+            , cast(CardType as string) as card_type
+        from source
+    )
+
+select *
+from renamed


### PR DESCRIPTION
### Why
Expose credit card reference (id + type) from OLTP for downstream marts without sensitive data.

### What changed
- Added `stg_sales__credit_card.sql` (select/rename from source).
- Documented & tested in `stg_sales.yml`:
  - `credit_card_id`: not_null, unique
  - `card_type`: not_null

### Checklist
- [x] All changed models run successfully (`dbt build`) for this branch.
- [x] Sources/models have descriptions (docs updated).
- [x] Tests added/updated and passing (not_null, unique, relationships, data tests when applicable).
- [x] Changes limited to this feature/scope (no unrelated files).
- [x] Naming & SQL style follow corporate guidelines.
