### PR TITLE
add int_sales__order_line (join header+detail with monetary calcs)

### DIFF
--- a/models/staging/sales/int_sales.yml
+++ b/models/staging/sales/int_sales.yml
@@ -1,0 +1,40 @@
+version: 2
+
+models:
+  - name: int_sales__order_line
+    description: "Order lines joined to headers with monetary calculations. Grain: one row per order line."
+    columns:
+      - name: sales_order_id
+        description: "Order natural key."
+      - name: sales_order_detail_id
+        description: "Order line identifier."
+      - name: product_id
+        description: "FK to product."
+      - name: order_date
+        description: "Order creation date."
+      - name: status_code
+        description: "Order status numeric code."
+      - name: customer_id
+        description: "FK to customer."
+      - name: ship_to_address_id
+        description: "FK to shipping address."
+      - name: credit_card_id
+        description: "FK to credit card used (nullable)."
+      - name: order_qty
+        description: "Quantity ordered."
+      - name: unit_price
+        description: "Unit price."
+      - name: unit_price_discount
+        description: "Unit discount rate (0..1)."
+      - name: gross_amount
+        description: "order_qty * unit_price."
+      - name: discount_amount
+        description: "order_qty * unit_price * unit_price_discount."
+      - name: net_amount
+        description: "gross_amount - discount_amount."
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [sales_order_id, sales_order_detail_id]
+      - dbt_utils.expression_is_true:
+          expression: "abs(net_amount - (gross_amount - discount_amount)) <= 0.01"
+          severity: warn

--- a/models/staging/sales/int_sales__order_line.sql
+++ b/models/staging/sales/int_sales__order_line.sql
@@ -1,0 +1,62 @@
+with
+    header as (
+        select
+              sales_order_id
+            , order_date
+            , status_code
+            , customer_id
+            , ship_to_address_id
+            , credit_card_id
+        from {{ ref('stg_sales__order_header') }}
+    )
+
+    , detail as (
+        select
+              sales_order_id
+            , sales_order_detail_id
+            , product_id
+            , order_qty
+            , unit_price
+            , unit_price_discount
+        from {{ ref('stg_sales__order_detail') }}
+    )
+
+    , joined as (
+        select
+            d.sales_order_id
+            , d.sales_order_detail_id
+            , d.product_id
+            , h.order_date
+            , h.status_code
+            , h.customer_id
+            , h.ship_to_address_id
+            , h.credit_card_id
+            , d.order_qty
+            , d.unit_price
+            , d.unit_price_discount
+            , cast(d.order_qty * d.unit_price                          as number(18,2)) as gross_amount
+            , cast(d.order_qty * d.unit_price * d.unit_price_discount  as number(18,2)) as discount_amount
+            , cast(
+                (d.order_qty * d.unit_price)
+                - (d.order_qty * d.unit_price * d.unit_price_discount) as number(18,2)) as net_amount
+        from detail d
+        inner join header h
+            on h.sales_order_id = d.sales_order_id
+    )
+
+select
+    sales_order_id
+    , sales_order_detail_id
+    , product_id
+    , order_date
+    , status_code
+    , customer_id
+    , ship_to_address_id
+    , credit_card_id
+    , order_qty
+    , unit_price
+    , unit_price_discount
+    , gross_amount
+    , discount_amount
+    , net_amount
+from joined


### PR DESCRIPTION
### Why
Consolidate order-line grain and compute gross/discount/net for marts.

### What changed
Add int_sales__order_line.sql + int_sales.yml (grain + calc consistency tests).

### Checklist
- [x] All changed models run successfully (`dbt build`) for this branch.
- [x] Sources/models have descriptions (docs updated).
- [x] Tests added/updated and passing (not_null, unique, relationships, data tests when applicable).
- [x] Changes limited to this feature/scope (no unrelated files).
- [x] Naming & SQL style follow corporate guidelines.
