### PR TITLE
add dim_product (surrogate key + attributes)

### DIFF
--- a/models/marts/sales/dim_product.sql
+++ b/models/marts/sales/dim_product.sql
@@ -1,0 +1,24 @@
+{{ config(materialized='table') }}
+
+with
+    source as (
+        select
+            product_id
+            , product_name
+            , subcategory_name
+            , category_name
+        from {{ ref('stg_production__product') }}
+    )
+
+    , final as (
+        select
+            {{ dbt_utils.generate_surrogate_key(['product_id']) }} as product_key
+            , cast(product_id as number(38,0))                     as product_id
+            , cast(product_name as string)                         as product_name
+            , cast(subcategory_name as string)                     as product_subcategory_name
+            , cast(category_name as string)                        as product_category_name
+        from source
+    )
+
+select *
+from final

--- a/models/marts/sales/dim_product.yml
+++ b/models/marts/sales/dim_product.yml
@@ -1,0 +1,23 @@
+version: 2
+
+models:
+  - name: dim_product
+    description: "Product dimension built from staging (1 row per product)."
+    columns:
+      - name: product_key
+        description: "Surrogate key (hash of product_id)."
+        tests: [not_null, unique]
+
+      - name: product_id
+        description: "Natural key from OLTP (Production.ProductID)."
+        tests: [not_null]
+
+      - name: product_name
+        description: "Product display name."
+        tests: [not_null]
+
+      - name: product_subcategory_name
+        description: "Optional subcategory name for the product."
+
+      - name: product_category_name
+        description: "Optional category name for the product."


### PR DESCRIPTION
### Why
Expose a clean product dimension with a surrogate key for downstream facts/BI.

### What changed
- Added `models/marts/sales/dim_product.sql`
- Added `models/marts/sales/dim_product.yml` (tests: product_key not_null/unique; product_id & product_name not_null)

### Checklist
- [x] All changed models run successfully (`dbt build`) for this branch.
- [x] Sources/models have descriptions (docs updated).
- [x] Tests added/updated and passing (not_null, unique, relationships, data tests when applicable).
- [x] Changes limited to this feature/scope (no unrelated files).
- [x] Naming & SQL style follow corporate guidelines.
