### PR TITLE
add dim_geography with surrogate key at city–state–country grain

### DIFF
--- a/models/marts/sales/dim_geography.sql
+++ b/models/marts/sales/dim_geography.sql
@@ -1,0 +1,31 @@
+{{ config(materialized='table') }}
+
+with src as (
+    select
+        city_name
+        , state_province_name
+        , state_province_code
+        , country_region_name
+        , country_region_code
+    from {{ ref('int_geography__ship_to') }}
+)
+
+select
+    {{ dbt_utils.generate_surrogate_key([
+        "'GE0'"
+        , "country_region_code"
+        , "state_province_code"
+        , "lower(city_name)"
+    ]) }}                                 as geography_key
+    , cast(city_name           as string) as city
+    , cast(state_province_name as string) as state_province
+    , cast(state_province_code as string) as state_province_code
+    , cast(country_region_name as string) as country
+    , cast(country_region_code as string) as country_code
+from src
+group by
+    city_name
+    , state_province_name
+    , state_province_code
+    , country_region_name
+    , country_region_code

--- a/models/marts/sales/sales_marts.yml
+++ b/models/marts/sales/sales_marts.yml
@@ -64,3 +64,32 @@ models:
       - name: card_type
         description: "Credit card brand/type"
         tests: [not_null]
+
+  - name: dim_geography
+    description: "Geography dimension at City–State–Country grain (ship-to)."
+    columns:
+      - name: geography_key
+        description: "Surrogate key (hash of country_code, state_province_code, city)."
+        tests: [not_null, unique]
+
+      - name: city
+        description: "City (ship-to)."
+        tests: [not_null]
+
+      - name: state_province
+        description: "State/Province name."
+        tests: [not_null]
+
+      - name: state_province_code
+        description: "State/Province code (from source)."
+        tests: [not_null]
+
+      - name: country
+        description: "Country/Region name."
+        tests: [not_null]
+
+      - name: country_code
+        description: "Country/Region code."
+        tests: [not_null]
+
+  


### PR DESCRIPTION
### Why
Create a geography dimension to support analyses by city, state, and country in BI dashboards, deduplicating addresses at the city–state–country grain.

### What changed
- Added `dim_geography.sql` in marts/sales:
  - Surrogate key `geography_key` generated with prefix GE0.
  - Grain defined as (city, state_province, country).
  - Normalization with lower/trim to avoid duplicates by case/spacing.
  - `group by` to ensure one row per combination.
- Updated `sales_marts.yml` with docs and tests:
  - `geography_key`: not_null, unique.
  - `city`, `state_province`, `state_province_code`, `country`, `country_code`: all not_null.

### Checklist
- [x] `dbt build -s dim_geography` runs successfully.
- [x] Sources/models have updated descriptions in YAML.
- [x] Tests for `dim_geography` passing (not_null, unique).
- [x] Changes limited to this scope.
- [x] Naming & SQL style follow corporate guidelines.