### PR TITLE
add dim_sales_reason with surrogate key + docs/tests

### DIFF
--- a/models/marts/sales/dim_product.sql
+++ b/models/marts/sales/dim_product.sql
@@ -1,7 +1,7 @@
 {{ config(materialized='table') }}
 
 with
-    source as (
+    src as (
         select
             product_id
             , product_name
@@ -17,7 +17,7 @@ with
             , cast(product_name as string)                         as product_name
             , cast(subcategory_name as string)                     as product_subcategory_name
             , cast(category_name as string)                        as product_category_name
-        from source
+        from src
     )
 
 select *

--- a/models/marts/sales/dim_sales_reason.sql
+++ b/models/marts/sales/dim_sales_reason.sql
@@ -1,0 +1,16 @@
+{{ config(materialized='table') }}
+
+with src as (
+    select
+        sales_reason_id
+        , reason_name
+        , reason_type
+    from {{ ref('stg_sales__sales_reason') }}
+)
+
+select
+    {{ dbt_utils.generate_surrogate_key(["'SR0'", "sales_reason_id"]) }} as sales_reason_key
+    , cast(sales_reason_id as number)                                    as sales_reason_id
+    , cast(reason_name     as string)                                    as reason_name
+    , cast(reason_type     as string)                                    as reason_type
+from src

--- a/models/marts/sales/sales_marts.yml
+++ b/models/marts/sales/sales_marts.yml
@@ -92,4 +92,23 @@ models:
         description: "Country/Region code."
         tests: [not_null]
 
+  - name: dim_sales_reason
+    description: "Sales reason dimension (e.g., Promotion, Marketing) with surrogate key."
+    columns:
+      - name: sales_reason_key
+        description: "Surrogate key (hash of SR0 + sales_reason_id)."
+        tests: [not_null, unique]
+
+      - name: sales_reason_id
+        description: "Natural key from SALES_SALESREASON."
+        tests: [not_null, unique]
+
+      - name: reason_name
+        description: "Sales reason name."
+        tests: [not_null]
+
+      - name: reason_type
+        description: "Category/type of sales reason."
+        tests: [not_null]
+
   


### PR DESCRIPTION
### Why
Provide a dimension for sales reasons (e.g., Promotion, Marketing) to support filtering and analysis of sales by reason.

### What changed
- Added `dim_sales_reason.sql` in marts/sales:
  - Surrogate key `sales_reason_key` with prefix SR0.
  - Grain defined as one row per sales_reason_id.
- Updated `sales_marts.yml` with docs and tests:
  - `sales_reason_key`: not_null, unique.
  - `sales_reason_id`: not_null, unique.
  - `reason_name` and `reason_type`: not_null.

### Checklist
- [x] `dbt build -s dim_sales_reason` runs successfully.
- [x] Sources/models have updated descriptions in YAML.
- [x] Tests for `dim_sales_reason` passing (not_null, unique).
- [x] Changes limited to this scope.
- [x] Naming & SQL style follow corporate guidelines.