### PR TITLE
add bridge_sales_reason linking orders to sales reason

### DIFF
--- a/models/marts/sales/bridge_sales_reason.sql
+++ b/models/marts/sales/bridge_sales_reason.sql
@@ -1,0 +1,22 @@
+{{ config(materialized='table') }}
+
+with src as (
+    select
+        sales_order_id    as order_id
+        , sales_reason_id as sales_reason_id
+    from {{ ref('stg_sales__order_sales_reason') }}
+)
+
+, joined as (
+    select
+        s.order_id
+        , d.sales_reason_key
+    from src s
+    inner join {{ ref('dim_sales_reason') }} d
+        on d.sales_reason_id = s.sales_reason_id
+)
+
+select distinct
+    cast(order_id as number) as order_id
+    , sales_reason_key
+from joined

--- a/models/marts/sales/sales_marts.yml
+++ b/models/marts/sales/sales_marts.yml
@@ -111,4 +111,23 @@ models:
         description: "Category/type of sales reason."
         tests: [not_null]
 
+  - name: bridge_sales_reason
+    description: "Bridge table linking orders to sales reasons (M:N)."
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [order_id, sales_reason_key]
+    columns:
+      - name: order_id
+        description: "Natural key of the order (from SALESORDERHEADER)."
+        tests: [not_null]
+
+      - name: sales_reason_key
+        description: "FK to dim_sales_reason."
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_sales_reason')
+                field: sales_reason_key
+
   


### PR DESCRIPTION
### Why
Provide a bridge table to resolve the many-to-many relationship between orders and sales reasons, enabling proper joins in marts and BI analysis.

### What changed
- Added `bridge_sales_reason.sql` in marts/sales:
  - Grain: one row per (order_id, sales_reason_key).
  - Ensures deduplication with `distinct`.
- Updated `sales_marts.yml` with docs and tests:
  - Unique combination of [order_id, sales_reason_key].
  - Not_null checks.
  - Relationship test to `dim_sales_reason`.

### Checklist
- [x] `dbt build -s bridge_sales_reason` runs successfully.
- [x] Sources/models have updated descriptions in YAML.
- [x] Tests for `bridge_sales_reason` passing (unique_combination, not_null, relationships).
- [x] Changes limited to this scope.
- [x] Naming & SQL style follow corporate guidelines.
