### PR TITLE
add dim_date for BI analysis

### DIFF
--- a/models/marts/sales/dim_date.sql
+++ b/models/marts/sales/dim_date.sql
@@ -1,0 +1,20 @@
+{{ config(materialized='table') }}
+
+with spine as (
+
+    {{ dbt_utils.date_spine(
+        datepart="day"
+        , start_date="cast('2000-01-01' as date)"
+        , end_date="cast('2030-12-31' as date)"
+    ) }}
+
+)
+
+select
+    cast(to_char(date_day, 'yyyymmdd') as number) as date_key
+    , date_day
+    , extract(year from date_day)                 as year
+    , extract(month from date_day)                as month
+    , to_char(date_day, 'Month')                  as month_name
+    , to_char(date_day, 'yyyy-mm')                as year_month
+from spine

--- a/models/marts/sales/sales_marts.yml
+++ b/models/marts/sales/sales_marts.yml
@@ -130,4 +130,31 @@ models:
                 to: ref('dim_sales_reason')
                 field: sales_reason_key
 
+  - name: dim_date
+    description: "Calendar dimension (one row per day) for time-based analysis."
+    columns:
+      - name: date_key
+        description: "Surrogate key in yyyymmdd format."
+        tests: [not_null, unique]
+
+      - name: date_day
+        description: "Actual date."
+        tests: [not_null, unique]
+
+      - name: year
+        description: "Year of the date."
+        tests: [not_null]
+
+      - name: month
+        description: "Month number (1–12)."
+        tests: [not_null]
+
+      - name: month_name
+        description: "Month name."
+        tests: [not_null]
+
+      - name: year_month
+        description: "Year-month string (YYYY-MM)."
+        tests: [not_null]
+
   


### PR DESCRIPTION
### Why
Provide a calendar dimension to support time-based analysis and joins in fct_sales. Keep attributes limited to what is necessary for the BI dashboard.

### What changed
- Added `dim_date.sql` in marts/common using `dbt_utils.date_spine`.
- Added `common_marts.yml` with docs and tests for `dim_date`.
- Attributes included: `date_key` (yyyymmdd), `date_day`, `year`, `month`, `month_name`, `year_month`.

### Checklist
- [x] `dbt build -s dim_date` runs successfully.
- [x] Sources/models have updated descriptions in YAML.
- [x] Tests for `dim_date` passing (not_null, unique).
- [x] Changes limited to this scope.
- [x] Naming & SQL style follow corporate guidelines.

