### PR TITLE
add fct_sales at order line grain with dimension FKs and metrics

### DIFF
--- a/models/marts/sales/fct_sales.sql
+++ b/models/marts/sales/fct_sales.sql
@@ -1,0 +1,114 @@
+{{ config(materialized='table') }}
+
+with lines as (
+    select
+        sales_order_id
+        , sales_order_detail_id
+        , product_id
+        , order_date
+        , status_code
+        , customer_id
+        , ship_to_address_id
+        , credit_card_id
+        , order_qty
+        , unit_price
+        , unit_price_discount
+        , gross_amount
+        , discount_amount
+        , net_amount
+    from {{ ref('int_sales__order_line') }}
+)
+
+, geo as (
+    select
+        address_id
+        , city_name
+        , state_province_code
+        , country_region_code
+    from {{ ref('int_geography__ship_to') }}
+)
+
+, joined as (
+    select
+        l.sales_order_id
+        , l.sales_order_detail_id
+        , l.product_id
+        , l.order_date
+        , l.status_code
+        , l.customer_id
+        , l.ship_to_address_id
+        , l.credit_card_id
+        , l.order_qty
+        , l.unit_price
+        , l.unit_price_discount
+        , l.gross_amount
+        , l.discount_amount
+        , l.net_amount
+        , g.city_name
+        , g.state_province_code
+        , g.country_region_code
+    from lines l
+    left join geo g
+        on g.address_id = l.ship_to_address_id
+)
+
+, dim_keys as (
+    select
+        j.sales_order_id
+        , j.sales_order_detail_id
+        , j.order_date
+        , j.status_code
+        , j.customer_id
+        , j.credit_card_id
+        , j.product_id
+        , j.order_qty
+        , j.unit_price
+        , j.unit_price_discount
+        , j.gross_amount
+        , j.discount_amount
+        , j.net_amount
+        , dpr.product_key
+        , dcu.customer_key
+        , dcc.credit_card_key
+        , dge.geography_key
+        , dde.date_key
+    from joined j
+    -- product
+    left join {{ ref('dim_product') }} dpr
+        on dpr.product_id = j.product_id
+    -- customer
+    left join {{ ref('dim_customer') }} dcu
+        on dcu.customer_id = j.customer_id
+    -- credit card (nullable)
+    left join {{ ref('dim_credit_card') }} dcc
+        on dcc.credit_card_id = j.credit_card_id
+    -- geography
+    left join {{ ref('dim_geography') }} dge
+        on  dge.country_code        = j.country_region_code
+        and dge.state_province_code = j.state_province_code
+        and lower(dge.city)         = lower(j.city_name)
+    -- date
+    left join {{ ref('dim_date') }} dde
+        on dde.date_day = j.order_date
+)
+
+select
+    {{ dbt_utils.generate_surrogate_key(
+        ["'FS0'", "sales_order_id", "sales_order_detail_id"]
+    ) }}                                          as sales_order_line_key
+    , cast(sales_order_id        as number)       as sales_order_id
+    , cast(sales_order_detail_id as number)       as sales_order_detail_id
+    , product_key
+    , customer_key
+    , credit_card_key
+    , geography_key
+    , date_key
+    , cast(status_code           as number)       as status_code
+
+    , cast(order_qty             as number(18,0)) as order_qty
+    , cast(unit_price            as number(18,2)) as unit_price
+    , cast(unit_price_discount   as number(9,4))  as unit_price_discount
+    , cast(gross_amount          as number(18,2)) as gross_amount
+    , cast(discount_amount       as number(18,2)) as discount_amount
+    , cast(net_amount            as number(18,2)) as net_amount
+from dim_keys

--- a/models/marts/sales/sales_marts.yml
+++ b/models/marts/sales/sales_marts.yml
@@ -157,4 +157,84 @@ models:
         description: "Year-month string (YYYY-MM)."
         tests: [not_null]
 
+  - name: fct_sales
+    description: >
+      Fact table at order line grain. Each row represents one sales order detail
+      with foreign keys to product, customer, credit card, geography, date,
+      and order status. Includes gross, discount, net amounts, and quantity.
+    columns:
+      - name: sales_order_line_key
+        description: "Surrogate key (hash of sales_order_id + sales_order_detail_id)."
+        tests: [not_null, unique]
+
+      - name: sales_order_id
+        description: "Natural key of the sales order (header)."
+        tests: [not_null]
+
+      - name: sales_order_detail_id
+        description: "Natural key of the line item within the order."
+        tests: [not_null]
+
+      - name: product_key
+        description: "FK to dim_product."
+        tests:
+          - not_null
+          - relationships:
+              to: ref('dim_product')
+              field: product_key
+
+      - name: customer_key
+        description: "FK to dim_customer."
+        tests:
+          - not_null
+          - relationships:
+              to: ref('dim_customer')
+              field: customer_key
+
+      - name: credit_card_key
+        description: "FK to dim_credit_card."
+        tests:
+          - relationships:
+              to: ref('dim_credit_card')
+              field: credit_card_key
+              severity: warn
+
+      - name: geography_key
+        description: "FK to dim_geography."
+        tests:
+          - not_null
+          - relationships:
+              to: ref('dim_geography')
+              field: geography_key
+
+      - name: date_key
+        description: "FK to dim_date."
+        tests:
+          - not_null
+          - relationships:
+              to: ref('dim_date')
+              field: date_key
+
+      - name: status_code
+        description: "Numeric order status code (to be mapped to dim_order_status later)."
+        tests: [not_null]
+
+      - name: order_qty
+        description: "Quantity purchased."
+        tests:
+          - not_null
+          - dbt_utils.expression_is_true:
+              expression: ">= 1"
+
+      - name: gross_amount
+        description: "Gross sales (unit_price * order_qty)."
+        tests: [not_null]
+
+      - name: discount_amount
+        description: "Discount amount (gross * unit_price_discount)."
+
+      - name: net_amount
+        description: "Net sales (gross - discount)."
+        tests: [not_null]
+
   


### PR DESCRIPTION
### Why
Create the central fact table for sales at order line grain, enabling joins with all related dimensions and supporting required business metrics.

### What changed
- Added `fct_sales.sql` in marts/sales:
  - Grain: one row per (sales_order_id, sales_order_detail_id).
  - Surrogate key `sales_order_line_key`.
  - Foreign keys to product, customer, credit card, geography, and date.
  - Metrics: order_qty, gross_amount, discount_amount, net_amount.
- Updated `sales_marts.yml` with docs and tests:
  - Surrogate key: not_null, unique.
  - FKs: not_null + relationships to corresponding dimensions.
  - Value checks on `order_qty` and metrics.

### Checklist
- [x] `dbt build -s fct_sales` runs successfully.
- [x] Sources/models have updated descriptions in YAML.
- [x] Tests for `fct_sales` passing (not_null, unique, relationships, value checks).
- [x] Changes limited to this scope.
- [x] Naming & SQL style follow corporate guidelines.
