### PR TITLE
add dim_order_status from seed (order_status.csv)

### DIFF
--- a/models/marts/sales/dim_order_status.sql
+++ b/models/marts/sales/dim_order_status.sql
@@ -1,0 +1,14 @@
+{{ config(materialized='table') }}
+
+with src as (
+    select
+        cast(order_status_code   as number) as status_code
+        , cast(order_status_name as string) as status_name
+    from {{ ref('order_status') }}  -- seed
+)
+
+select
+    {{ dbt_utils.generate_surrogate_key(["'OS0'", "status_code"]) }} as order_status_key
+    , status_code
+    , status_name
+from src

--- a/models/marts/sales/sales_marts.yml
+++ b/models/marts/sales/sales_marts.yml
@@ -237,4 +237,21 @@ models:
         description: "Net sales (gross - discount)."
         tests: [not_null]
 
+  - name: dim_order_status
+    description: "Order status dimension (seed-based mapping from numeric code to readable name)."
+    columns:
+      - name: order_status_key
+        description: "Surrogate key for order status."
+        tests: [not_null, unique]
+
+      - name: status_code
+        description: "Numeric status code from the source system."
+        tests:
+          - not_null
+          - unique
+
+      - name: status_name
+        description: "Human-readable status label."
+        tests: [not_null]
+
   


### PR DESCRIPTION
### Why
Provide a readable order status dimension sourced from a seed, to replace numeric status codes in analysis.

### What changed
- Added `seeds/order_status.csv` (status_code → status_name).
- Added `dim_order_status.sql` in marts/sales with surrogate key `order_status_key`.
- Updated `sales_marts.yml` with docs and tests for `dim_order_status`.

### Checklist
- [x] `dbt seed -s order_status` runs successfully.
- [x] `dbt build -s dim_order_status` runs successfully.
- [x] Tests passing for `dim_order_status` (not_null, unique).
- [x] Changes limited to this scope.
- [x] Naming & SQL style follow corporate guidelines.
