### PR TITLE
link fct_sales to dim_order_status via status_code (+yaml tests)

### DIFF
--- a/models/marts/sales/fct_sales.sql
+++ b/models/marts/sales/fct_sales.sql
@@ -72,6 +72,7 @@ with lines as (
         , dcc.credit_card_key
         , dge.geography_key
         , dde.date_key
+        , dos.order_status_key
     from joined j
     -- product
     left join {{ ref('dim_product') }} dpr
@@ -90,6 +91,9 @@ with lines as (
     -- date
     left join {{ ref('dim_date') }} dde
         on dde.date_day = j.order_date
+    -- order status (seed-based dim)
+    left join {{ ref('dim_order_status') }} dos
+        on dos.status_code = j.status_code
 )
 
 select
@@ -103,8 +107,8 @@ select
     , credit_card_key
     , geography_key
     , date_key
+    , order_status_key
     , cast(status_code           as number)       as status_code
-
     , cast(order_qty             as number(18,0)) as order_qty
     , cast(unit_price            as number(18,2)) as unit_price
     , cast(unit_price_discount   as number(9,4))  as unit_price_discount

--- a/models/marts/sales/sales_marts.yml
+++ b/models/marts/sales/sales_marts.yml
@@ -215,8 +215,16 @@ models:
               to: ref('dim_date')
               field: date_key
 
+      - name: order_status_key
+        description: "FK to dim_order_status."
+        tests:
+          - not_null
+          - relationships:
+              to: ref('dim_order_status')
+              field: order_status_key
+
       - name: status_code
-        description: "Numeric order status code (to be mapped to dim_order_status later)."
+        description: "Numeric order status code from the source (kept for audit)."
         tests: [not_null]
 
       - name: order_qty


### PR DESCRIPTION
### Why
Expose readable order status in analytics by linking fct_sales to dim_order_status (seed-based), avoiding numeric codes in BI.

### What changed
- Updated `fct_sales.sql` to join `dim_order_status` and select `order_status_key`.
- Updated `sales_marts.yml` to add tests (not_null + relationships) for `order_status_key`.

### Checklist
- [x] `dbt build -s fct_sales` runs successfully.
- [x] Sources/models have updated descriptions in YAML.
- [x] Tests passing for `fct_sales` (relationships to dim_order_status).
- [x] Changes limited to this scope.
- [x] Naming & SQL style follow corporate guidelines.

