### PR TITLE
add prefix to surrogate keys in dim_product, dim_customer, dim_credit…

### DIFF
--- a/models/marts/sales/dim_credit_card.sql
+++ b/models/marts/sales/dim_credit_card.sql
@@ -8,7 +8,7 @@ with src as (
 )
 
 select
-    {{ dbt_utils.generate_surrogate_key(['credit_card_id']) }} as credit_card_key
+    {{ dbt_utils.generate_surrogate_key(["'CC0'", "credit_card_id"]) }} as credit_card_key
     , cast(credit_card_id as number)                           as credit_card_id
     , cast(card_type      as string)                           as card_type
 from src

--- a/models/marts/sales/dim_customer.sql
+++ b/models/marts/sales/dim_customer.sql
@@ -12,7 +12,7 @@ with
     )
 
 select
-    {{ dbt_utils.generate_surrogate_key(['customer_id']) }} as customer_key
+    {{ dbt_utils.generate_surrogate_key(["'CU0'", "customer_id"]) }} as customer_key
     , cast(customer_id   as number)                         as customer_id
     , cast(customer_type as string)                         as customer_type
     , cast(customer_name as string)                         as customer_name

--- a/models/marts/sales/dim_product.sql
+++ b/models/marts/sales/dim_product.sql
@@ -12,7 +12,7 @@ with
 
     , final as (
         select
-            {{ dbt_utils.generate_surrogate_key(['product_id']) }} as product_key
+            {{ dbt_utils.generate_surrogate_key(["'PR0'", "product_id"]) }} as product_key
             , cast(product_id as number(38,0))                     as product_id
             , cast(product_name as string)                         as product_name
             , cast(subcategory_name as string)                     as product_subcategory_name


### PR DESCRIPTION
### Why
Ensure consistency in surrogate key naming across all dimensions.  
Previously, only some dims had prefixes (`GE0`, `DT0`, `SR0`, etc.).  
This change adds prefixes to product, customer, and credit card keys for clarity and standardization.

### What changed
- Updated `dim_product.sql`: surrogate key now generated with prefix `PR0`.
- Updated `dim_customer.sql`: surrogate key now generated with prefix `CU0`.
- Updated `dim_credit_card.sql`: surrogate key now generated with prefix `CC0`.
- Ran full-refresh build to propagate new keys into `fct_sales`.

### Checklist
- [x] `dbt build --full-refresh` runs successfully for impacted models.
- [x] Sources/models have updated descriptions in YAML if needed.
- [x] Tests for affected dims and `fct_sales` passing (not_null, unique, relationships).
- [x] Changes limited to this scope.
- [x] Naming & SQL style follow corporate guidelines.