### PR TITLE
add singular data test for 2011 gross sales total

### DIFF
--- a/tests/data/test_gross_sales_2011.sql
+++ b/tests/data/test_gross_sales_2011.sql
@@ -1,0 +1,13 @@
+-- Fails if the sum of gross_amount for 2011 deviates from the expected value (tolerance of 0.01)
+
+with calc as (
+    select
+        round(sum(f.gross_amount), 2) as total_gross_2011
+    from {{ ref('fct_sales') }} f
+    join {{ ref('dim_date') }} d
+        on d.date_key = f.order_date_key
+    where d.year = 2011
+)
+select total_gross_2011
+from calc
+where abs(total_gross_2011 - 12646112.16) > 0.01


### PR DESCRIPTION
### Why
Validate the CEO’s audit figure: gross sales in 2011 must equal 12,646,112.16.

### What changed
- Added `tests/data/test_gross_sales_2011.sql` (singular data test; tolerance 0.01).

### Checklist
- [x] `dbt build -s fct_sales dim_date` successful before testing.
- [x] `dbt test -s test_gross_sales_2011` passes.
- [x] Changes limited to this scope.
- [x] Naming & SQL style follow corporate guidelines.